### PR TITLE
Make read/write operations to be thread-safe on the map of ZWave devices

### DIFF
--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -2486,6 +2486,7 @@ void COpenZWave::UpdateValue(const OpenZWave::ValueID &vID)
 
 	_tZWaveDevice *pDevice = NULL;
 	std::map<std::string, _tZWaveDevice>::iterator itt;
+	boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 	for (itt = m_devices.begin(); itt != m_devices.end(); ++itt)
 	{
 		std::string::size_type loc = path.find(itt->second.string_id, 0);
@@ -2495,6 +2496,8 @@ void COpenZWave::UpdateValue(const OpenZWave::ValueID &vID)
 			break;
 		}
 	}
+	devicesMutexLock.unlock();
+
 	if (pDevice == NULL)
 		return;
 

--- a/hardware/Razberry.cpp
+++ b/hardware/Razberry.cpp
@@ -611,6 +611,7 @@ void CRazberry::UpdateDevice(const std::string &path, const Json::Value &obj)
 	if (pDevice==NULL)
 	{
 		std::map<std::string,_tZWaveDevice>::iterator itt;
+		boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 		for (itt=m_devices.begin(); itt!=m_devices.end(); ++itt)
 		{
 			std::string::size_type loc = path.find(itt->second.string_id,0);
@@ -690,6 +691,7 @@ void CRazberry::UpdateDevice(const std::string &path, const Json::Value &obj)
 
 		bool bFoundInstance=false;
 		int oldinstance=_device.instanceID;
+		boost::shared_lock<boost::shared_mutex> devicesMutexLock1(m_devicesMutex);
 		for (int iInst=0; iInst<7; iInst++)
 		{
 			_device.instanceID=iInst;
@@ -701,6 +703,8 @@ void CRazberry::UpdateDevice(const std::string &path, const Json::Value &obj)
 				break;
 			}
 		}
+		devicesMutexLock1.unlock();
+
 		if (!bFoundInstance)
 			_device.instanceID=oldinstance;
 
@@ -708,9 +712,11 @@ void CRazberry::UpdateDevice(const std::string &path, const Json::Value &obj)
 
 		//find device again
 		std:: string devicestring_id=GenerateDeviceStringID(&_device);
+		boost::shared_lock<boost::shared_mutex> devicesMutexLock2(m_devicesMutex);
 		std::map<std::string,_tZWaveDevice>::iterator iDevice=m_devices.find(devicestring_id);
 		if (iDevice==m_devices.end())
 			return; //uhuh?
+		devicesMutexLock2.unlock();
 		pDevice=&iDevice->second;
 	}
 
@@ -824,6 +830,7 @@ void CRazberry::UpdateDevice(const std::string &path, const Json::Value &obj)
 ZWaveBase::_tZWaveDevice* CRazberry::FindDeviceByScale(const int nodeID, const int scaleID, const int cmdID)
 {
 	std::map<std::string,_tZWaveDevice>::iterator itt;
+	boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 	for (itt=m_devices.begin(); itt!=m_devices.end(); ++itt)
 	{
 		if (
@@ -839,6 +846,7 @@ ZWaveBase::_tZWaveDevice* CRazberry::FindDeviceByScale(const int nodeID, const i
 ZWaveBase::_tZWaveDevice* CRazberry::FindDeviceInstance(const int nodeID, const int instanceID, const int cmdID)
 {
 	std::map<std::string,_tZWaveDevice>::iterator itt;
+	boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 	for (itt=m_devices.begin(); itt!=m_devices.end(); ++itt)
 	{
 		if (

--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -129,6 +129,8 @@ void ZWaveBase::InsertDevice(_tZWaveDevice device)
 {
 	device.string_id=GenerateDeviceStringID(&device);
 
+	boost::unique_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
+
 	bool bNewDevice=(m_devices.find(device.string_id)==m_devices.end());
 	
 	device.lastreceived=mytime(NULL);
@@ -152,6 +154,7 @@ void ZWaveBase::InsertDevice(_tZWaveDevice device)
 void ZWaveBase::UpdateDeviceBatteryStatus(const int nodeID, const int value)
 {
 	std::map<std::string,_tZWaveDevice>::iterator itt;
+	boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 	for (itt=m_devices.begin(); itt!=m_devices.end(); ++itt)
 	{
 		if (itt->second.nodeID==nodeID)
@@ -921,6 +924,7 @@ void ZWaveBase::SendDevice2Domoticz(const _tZWaveDevice *pDevice)
 ZWaveBase::_tZWaveDevice* ZWaveBase::FindDevice(const int nodeID, const int instanceID, const int indexID)
 {
 	std::map<std::string, _tZWaveDevice>::iterator itt;
+	boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 	for (itt = m_devices.begin(); itt != m_devices.end(); ++itt)
 	{
 		if (
@@ -936,6 +940,7 @@ ZWaveBase::_tZWaveDevice* ZWaveBase::FindDevice(const int nodeID, const int inst
 ZWaveBase::_tZWaveDevice* ZWaveBase::FindDevice(const int nodeID, const int instanceID, const int indexID, const _eZWaveDeviceType devType)
 {
 	std::map<std::string,_tZWaveDevice>::iterator itt;
+	boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 	for (itt=m_devices.begin(); itt!=m_devices.end(); ++itt)
 	{
 		if (
@@ -951,6 +956,7 @@ ZWaveBase::_tZWaveDevice* ZWaveBase::FindDevice(const int nodeID, const int inst
 ZWaveBase::_tZWaveDevice* ZWaveBase::FindDevice(const int nodeID, const int instanceID, const int indexID, const int CommandClassID,  const _eZWaveDeviceType devType)
 {
 	std::map<std::string,_tZWaveDevice>::iterator itt;
+	boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 	for (itt=m_devices.begin(); itt!=m_devices.end(); ++itt)
 	{
 		if (
@@ -1239,6 +1245,7 @@ bool ZWaveBase::WriteToHardware(const char *pdata, const unsigned char length)
 void ZWaveBase::ForceUpdateForNodeDevices(const unsigned int homeID, const int nodeID)
 {
 	std::map<std::string, _tZWaveDevice>::iterator itt;
+	boost::shared_lock<boost::shared_mutex> devicesMutexLock(m_devicesMutex);
 	for (itt = m_devices.begin(); itt != m_devices.end(); ++itt)
 	{
 		if (itt->second.nodeID == nodeID)

--- a/hardware/ZWaveBase.h
+++ b/hardware/ZWaveBase.h
@@ -162,6 +162,7 @@ private:
 	time_t m_updateTime;
 	bool m_bInitState;
 	std::map<std::string,_tZWaveDevice> m_devices;
+	boost::shared_mutex m_devicesMutex;
 	boost::shared_ptr<boost::thread> m_thread;
 	bool m_stoprequested;
 };


### PR DESCRIPTION
(because it is accessed from two different threads).
