### PR TITLE
"Temperatue, Wind... graphs are missing !" solution ;-)

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -10798,7 +10798,7 @@ namespace http {
 			unsigned char dType = atoi(result[0][0].c_str());
 			unsigned char dSubType = atoi(result[0][1].c_str());
 			_eMeterType metertype = (_eMeterType)atoi(result[0][2].c_str());
-			if ((dType == pTypeP1Power) || (dType == pTypeENERGY) || (dType == pTypePOWER) || ((dType = pTypeGeneral) && (dSubType == sTypeKwh)))
+			if ((dType == pTypeP1Power) || (dType == pTypeENERGY) || (dType == pTypePOWER) || ((dType == pTypeGeneral) && (dSubType == sTypeKwh)))
 				metertype = MTYPE_ENERGY;
 			else if (dType == pTypeP1Gas)
 				metertype = MTYPE_GAS;


### PR DESCRIPTION
This patch fixes an issue on the release 3037 : all day, week, month, year graphs are missing for Temperature, Wind, UV... devices.
